### PR TITLE
Fix createDashboards task failing on namespace template variable

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,7 +54,8 @@ val createPrometheusDashboard by tasks.registering {
         // remove influxdb datasource variable
         val datasourceVariables = dashboard["templating"].asJsonObject["list"]
         datasourceVariables.asJsonArray.asList().removeIf {
-            it.asJsonObject["query"].asString == "influxdb"
+            val query = it.asJsonObject["query"]
+            query.isJsonPrimitive && query.asString == "influxdb"
         }
 
         // rename the dashboard
@@ -98,7 +99,8 @@ val createInfluxDbDashboard by tasks.registering {
         // remove prometheus datasource variable
         val datasourceVariables = dashboard["templating"].asJsonObject["list"]
         datasourceVariables.asJsonArray.asList().removeIf {
-            it.asJsonObject["query"].asString == "prometheus"
+            val query = it.asJsonObject["query"]
+            query.isJsonPrimitive && query.asString == "prometheus"
         }
 
         // rename the dashboard


### PR DESCRIPTION
## Summary
- The `namespace` template variable added in 9c5e4e2 has a JSON object `query` field, not a string
- Both `createPrometheusDashboard` and `createInfluxDbDashboard` tasks called `getAsString()` on it, causing an `UnsupportedOperationException: JsonObject`
- Added `isJsonPrimitive` check before calling `asString` in both tasks