### PR TITLE
Add incoming bandwidth throttling panels and dedicated OP/throttling row

### DIFF
--- a/hivemq-grafana-dashboard-combined.json
+++ b/hivemq-grafana-dashboard-combined.json
@@ -3507,108 +3507,10 @@
         "x": 0,
         "y": 47
       },
-      "id": 39,
-      "panels": [],
-      "title": "HiveMQ Cluster",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "datasource",
-        "uid": "-- Mixed --"
-      },
-      "description": "The number of nodes in the cluster.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "axisSoftMin": 0,
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": []
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 3,
-        "x": 0,
-        "y": 48
-      },
-      "id": 40,
-      "interval": "${intervalSeconds}s",
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": false
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${Prometheus}"
-          },
-          "editorMode": "code",
-          "expr": "com_hivemq_cluster_nodes_count{namespace=~\"$namespace\"}",
-          "instant": false,
-          "legendFormat": "{{instance}} nodes",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "influxdb",
-            "uid": "${InfluxDB}"
-          },
-          "hide": false,
-          "query": "from(bucket: v.defaultBucket)\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"com.hivemq.cluster.nodes.count\")\n  |> aggregateWindow(every: ${intervalSeconds}s, fn: mean)\n  |> drop(columns: [\"_start\", \"_stop\", \"_measurement\", \"metricName\", \"_field\"])",
-          "refId": "B"
-        }
-      ],
-      "title": "Cluster Nodes",
-      "type": "timeseries"
+      "id": 129,
+      "title": "Overload Protection & Throttling",
+      "type": "row",
+      "panels": []
     },
     {
       "datasource": {
@@ -3665,7 +3567,7 @@
       "gridPos": {
         "h": 7,
         "w": 3,
-        "x": 3,
+        "x": 0,
         "y": 48
       },
       "id": 97,
@@ -3762,8 +3664,8 @@
       },
       "gridPos": {
         "h": 7,
-        "w": 6,
-        "x": 6,
+        "w": 3,
+        "x": 3,
         "y": 48
       },
       "id": 100,
@@ -3804,7 +3706,203 @@
           "refId": "B"
         }
       ],
-      "title": "Overload Protection backpressure active",
+      "title": "Overload Protection Backpressure Active",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Mixed --"
+      },
+      "description": "The number of client connections whose reads are currently suspended because the configured incoming-bandwidth-throttling limit is being enforced. A value greater than 0 means incoming bandwidth throttling is currently active.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMin": 0,
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 3,
+        "x": 6,
+        "y": 48
+      },
+      "id": 127,
+      "interval": "${intervalSeconds}s",
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Prometheus}"
+          },
+          "editorMode": "code",
+          "expr": "com_hivemq_networking_incoming_bandwidth_throttling_connections_current{namespace=~\"$namespace\"}",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${InfluxDB}"
+          },
+          "hide": false,
+          "query": "from(bucket: v.defaultBucket)\n    |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n    |> filter(fn: (r) => r[\"_measurement\"] == \"com.hivemq.networking.incoming-bandwidth-throttling.connections.current\")\n    |> drop(columns: [\"_start\", \"_stop\", \"metricName\", \"_field\"])\n    |> aggregateWindow(every: ${intervalSeconds}s, fn: max)",
+          "refId": "B"
+        }
+      ],
+      "title": "Currently Throttled Connections",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Mixed --"
+      },
+      "description": "Counts each time a client connection's reads are suspended because the configured incoming-bandwidth-throttling limit is being enforced",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMin": 0,
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 3,
+        "x": 9,
+        "y": 48
+      },
+      "id": 128,
+      "interval": "${intervalSeconds}s",
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${Prometheus}"
+          },
+          "editorMode": "code",
+          "expr": "rate(com_hivemq_networking_incoming_bandwidth_throttling_connections_count{namespace=~\"$namespace\"}[${intervalSeconds}s])",
+          "instant": false,
+          "legendFormat": "{{job}} throttle-events",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "influxdb",
+            "uid": "${InfluxDB}"
+          },
+          "hide": false,
+          "query": "from(bucket: v.defaultBucket)\n    |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n    |> filter(fn: (r) => r[\"_measurement\"] == \"com.hivemq.networking.incoming-bandwidth-throttling.connections.count\")\n    |> drop(columns: [\"_start\", \"_stop\", \"metricName\", \"_field\"])\n    |> aggregateWindow(every: ${intervalSeconds}s, fn: max)\n    |> map(fn: (r) => ({ r with _value: r._value / ${intervalSeconds}.0 }))\n    |> difference(nonNegative: true)",
+          "refId": "B"
+        }
+      ],
+      "title": "Throttle Events/s",
       "type": "timeseries"
     },
     {


### PR DESCRIPTION
https://linear.app/hivemq/issue/BCD-478/new-metrics-to-track-incoming-bandwidth-throttling

Incorporate the two incoming bandwidth throttling metrics added in hivemq-enterprise 574f9db (PR #4527):
  - com.hivemq.networking.incoming-bandwidth-throttling.connections.current
  - com.hivemq.networking.incoming-bandwidth-throttling.connections.count

Group broker self-protection signals into a new "Overload Protection & Throttling" row and remove the now-redundant "HiveMQ Cluster" row:
  - Move the two Overload Protection panels out of the Cluster row
  - Add "Currently Throttled Connections" (gauge) and "Throttle Events/s" (rate) panels, each with Prometheus and InfluxDB targets and a description
  - Drop the Cluster row and its Cluster Nodes panel, which only duplicated the Cluster Nodes panel already shown in Overview
  - Normalize the Backpressure Active panel width and capitalize its title

**Motivation**

**Changes**
